### PR TITLE
Fix text truncation in long sentences and pipeline sequence handling

### DIFF
--- a/node.py
+++ b/node.py
@@ -336,7 +336,7 @@ class GeekyKokoroTTSNode:
                     parts = re.split(r'([,;])', current_chunk)
                     temp_chunk = ""
 
-                    for j in range(0, len(parts)-1, 2):
+                    for j in range(0, len(parts), 2):
                         part = parts[j] + (parts[j+1] if j+1 < len(parts) else '')
 
                         if temp_chunk and len(temp_chunk + part) > max_chunk_size:
@@ -386,27 +386,34 @@ class GeekyKokoroTTSNode:
                     logger.warning(f"No phonemes generated for chunk {i+1}")
                     continue
 
-                _, ps, _ = phoneme_sequences[0]
+                chunk_parts = []
+                
+                for _, ps, _ in phoneme_sequences:
+                    if not ps: 
+                        continue
+                        
+                    ref_s_chunk = ref_s if ref_s is not None else pipeline.load_voice(voice_code)[len(ps)-1]
 
-                ref_s_chunk = ref_s if ref_s is not None else pipeline.load_voice(voice_code)[len(ps)-1]
+                    with self.MODEL_LOCK:
+                        if use_gpu and True not in self.MODEL and torch.cuda.is_available():
+                            try:
+                                self.MODEL[True] = KModel().to('cuda').eval()
+                            except Exception as gpu_e:
+                                logger.warning(f"Failed to load GPU model: {gpu_e}. Using CPU.")
+                                use_gpu = False
 
-                with self.MODEL_LOCK:
-                    if use_gpu and True not in self.MODEL and torch.cuda.is_available():
                         try:
-                            self.MODEL[True] = KModel().to('cuda').eval()
-                        except Exception as gpu_e:
-                            logger.warning(f"Failed to load GPU model: {gpu_e}. Using CPU.")
+                            audio = self.MODEL[use_gpu and True in self.MODEL](ps, ref_s_chunk, speed)
+                        except Exception as gen_e:
+                            logger.warning(f"GPU generation failed for chunk {i+1}: {gen_e}. Trying CPU.")
                             use_gpu = False
+                            audio = self.MODEL[False](ps, ref_s_chunk, speed)
 
-                    try:
-                        audio = self.MODEL[use_gpu and True in self.MODEL](ps, ref_s_chunk, speed)
-                    except Exception as gen_e:
-                        logger.warning(f"GPU generation failed for chunk {i+1}: {gen_e}. Trying CPU.")
-                        use_gpu = False
-                        audio = self.MODEL[False](ps, ref_s_chunk, speed)
-
-                audio_np = audio.cpu().numpy() if isinstance(audio, torch.Tensor) else audio
-                all_audio.append(audio_np)
+                    audio_np = audio.cpu().numpy() if isinstance(audio, torch.Tensor) else audio
+                    chunk_parts.append(audio_np)
+                
+                if chunk_parts:
+                    all_audio.append(np.concatenate(chunk_parts))
 
             except Exception as e:
                 logger.error(f"Failed to process chunk {i+1}: {e}")


### PR DESCRIPTION
This PR fixes two critical bugs that caused text to be truncated or skipped during generation:

**1. Fix in `_process_text_chunks`:**
* **Problem:** The code was only taking the first element (`[0]`) from the `phoneme_sequences` list returned by the pipeline. If the Kokoro pipeline split a single chunk into multiple sequences (e.g., due to internal logic or newlines), the subsequent parts were silently dropped.
* **Fix:** Iterated through all returned sequences in the chunk to ensure all audio is generated and concatenated.


**2. Fix in `_improved_text_chunking`:**
* **Problem:** In the logic for handling "very long sentences", the loop `range(0, len(parts)-1, 2)` caused the very last part of the split text to be ignored/dropped because of the `-1`.
* **Fix:** Changed the loop range to correctly process all parts of the split sentence.


**Testing:**
Tested with text that previously failed (e.g., "The Thumbstopper/Bumper" example where the middle part was missing). Both the title and the body of the text are now generated correctly.


**Testing text example (the part that would be missing is highlighted here using italics):**
The Thumbstopper/Bumper
*This is the much maligned "teaser before the trailer" technique which is now ubiquitous on the internet mostly for movies; some games have adopted it too. This is where the first six seconds of the trailer flashes a series of images from the full trailer, and ends in a title card.* I'd consider this the most brute force way of getting the audience to pay attention. These are also called “bumpers” in the trailer industry.